### PR TITLE
Auto claim

### DIFF
--- a/src/lib/client/Maci.client.ts
+++ b/src/lib/client/Maci.client.ts
@@ -400,6 +400,11 @@ export interface MaciInterface extends MaciReadOnlyInterface {
     memo?: string,
     _funds?: Coin[],
   ) => Promise<ExecuteResult>
+  claim: (
+    fee?: number | StdFee | 'auto',
+    memo?: string,
+    _funds?: Coin[],
+  ) => Promise<ExecuteResult>
 }
 export class MaciClient extends MaciQueryClient implements MaciInterface {
   client: SigningCosmWasmClient
@@ -435,6 +440,7 @@ export class MaciClient extends MaciQueryClient implements MaciInterface {
     this.revoke = this.revoke.bind(this)
     this.bond = this.bond.bind(this)
     this.withdraw = this.withdraw.bind(this)
+    this.claim = this.claim.bind(this)
   }
 
   setParams = async (
@@ -891,6 +897,22 @@ export class MaciClient extends MaciQueryClient implements MaciInterface {
         withdraw: {
           amount,
         },
+      },
+      fee,
+      memo,
+      _funds,
+    )
+  }
+  claim = async (
+    fee: number | StdFee | 'auto' = 'auto',
+    memo?: string,
+    _funds?: Coin[],
+  ): Promise<ExecuteResult> => {
+    return await this.client.execute(
+      this.sender,
+      this.contractAddress,
+      {
+        claim: {},
       },
       fee,
       memo,

--- a/src/task/tally.ts
+++ b/src/task/tally.ts
@@ -253,5 +253,14 @@ export const tally: TaskAct = async (_, { id }: { id: string }) => {
     }
   }
 
+  // when finished tally operation, claim the reward
+  console.log('Executing claim operation.....')
+  try {
+    const claimResult = await maciClient.claim('auto')
+    console.log('Claim operation completed successfully, tx hash:', claimResult.transactionHash)
+  } catch (error) {
+    console.log('Error during claim operation:', error)
+  }
+
   return {}
 }

--- a/src/task/tally.ts
+++ b/src/task/tally.ts
@@ -239,7 +239,6 @@ export const tally: TaskAct = async (_, { id }: { id: string }) => {
       log('processTally', ui, res)
     }
 
-    // 使用批量操作方法替代单独的操作
     try {
       console.log('Executing stopTallying and claim as batch operation...')
       const batchResult = await maciClient.stopTallyingAndClaim({
@@ -250,7 +249,6 @@ export const tally: TaskAct = async (_, { id }: { id: string }) => {
     } catch (error) {
       console.log('Error during batch operation:', error)
       
-      // 如果批量操作失败，尝试单独执行
       console.log('Trying operations separately...')
       try {
         await maciClient.stopTallyingPeriod({
@@ -268,7 +266,6 @@ export const tally: TaskAct = async (_, { id }: { id: string }) => {
   } else {
     const period = await maciClient.getPeriod()
     if (period.status === 'tallying') {
-      // 同样使用批量操作
       try {
         console.log('Executing stopTallying and claim as batch operation...')
         const batchResult = await maciClient.stopTallyingAndClaim({
@@ -279,7 +276,6 @@ export const tally: TaskAct = async (_, { id }: { id: string }) => {
       } catch (error) {
         console.log('Error during batch operation:', error)
         
-        // 如果批量操作失败，尝试单独执行
         console.log('Trying operations separately...')
         try {
           await maciClient.stopTallyingPeriod({


### PR DESCRIPTION
When the operator finishes processing the round, that is, at `stopTally`, it will automatically `claim` the reward from the contract. This operation will automatically complete the reward distribution for all relevant participants.
- To ensure that the claim can be successfully executed after stoptally and to avoid uncertainties caused by the time interval between the two operations, place stoptally and claim in a single vota transaction on the blockchain.
- If the creator claims in advance, the operator executing the claim may cause the batch transaction to fail. In this case, stoptally and claim will be executed separately, but the claim is bound to fail.