### PR TITLE
feat: add resumable zkey downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v2.4.1] - 2026-08-06
+
+### Added
+
+- Added download progress reporting for both interactive terminals and
+  systemd/journal environments.
+- Added persistent partial archives and HTTP Range requests so interrupted
+  zkey downloads resume across retries and operator restarts.
+
 ## [v2.4.0] - 2026-08-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@dorafactory/maci-operator",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@dorafactory/maci-operator",
-            "version": "2.4.0",
+            "version": "2.4.1",
             "license": "ISC",
             "dependencies": {
                 "@cosmjs/cosmwasm-stargate": "^0.32.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dorafactory/maci-operator",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "description": "An operator for managing MACI (Minimal Anti-Collusion Infrastructure)/aMACI deployments and interactions.",
     "main": "dist/index.js",
     "bin": {

--- a/src/lib/downloadZkeys.test.ts
+++ b/src/lib/downloadZkeys.test.ts
@@ -1,8 +1,18 @@
 import fs from 'fs'
+import { EventEmitter } from 'events'
+import type { IncomingMessage } from 'http'
+import * as https from 'https'
 import os from 'os'
 import path from 'path'
+import { PassThrough } from 'stream'
 import { afterEach, describe, expect, it } from 'vitest'
-import { verifyArchiveChecksum } from './downloadZkeys'
+import {
+  createDownloadProgressReporter,
+  downloadZKeys,
+  formatDownloadProgress,
+  parseContentRange,
+  verifyArchiveChecksum,
+} from './downloadZkeys'
 
 let tmpDir = ''
 
@@ -20,5 +30,167 @@ describe('verifyArchiveChecksum', () => {
     await expect(
       verifyArchiveChecksum('9-4-3-125_v6', archivePath),
     ).rejects.toThrow('SHA256 mismatch for 9-4-3-125_v6')
+  })
+})
+
+describe('download progress', () => {
+  it('formats percentage, size, speed, and ETA', () => {
+    const gib = 1024 ** 3
+    const progress = formatDownloadProgress(4 * gib, 8 * gib, 2_000)
+
+    expect(progress).toContain('50.0%')
+    expect(progress).toContain('4.0 GiB / 8.0 GiB')
+    expect(progress).toContain('2.0 GiB/s')
+    expect(progress).toContain('ETA 2s')
+  })
+
+  it('emits periodic progress lines when stdout is not a TTY', () => {
+    let now = 0
+    const logs: string[] = []
+    const progress = createDownloadProgressReporter('bundle.tar.gz', 100, {
+      isTTY: false,
+      log: (message) => logs.push(message),
+      now: () => now,
+      logIntervalMs: 10_000,
+      percentStep: 25,
+    })
+
+    progress.update(10)
+    progress.update(25)
+    now = 10_000
+    progress.update(30)
+    progress.complete(100)
+
+    expect(logs).toHaveLength(4)
+    expect(logs[0]).toContain('0.0%')
+    expect(logs[1]).toContain('25.0%')
+    expect(logs[2]).toContain('30.0%')
+    expect(logs[3]).toContain('Downloaded bundle.tar.gz')
+    expect(logs[3]).toContain('100.0%')
+  })
+
+  it('starts resumed progress from the existing byte count', () => {
+    const logs: string[] = []
+    const progress = createDownloadProgressReporter('bundle.tar.gz', 100, {
+      isTTY: false,
+      initialBytes: 50,
+      log: (message) => logs.push(message),
+    })
+
+    progress.complete(100)
+
+    expect(logs[0]).toContain('Resuming bundle.tar.gz')
+    expect(logs[0]).toContain('50.0%')
+    expect(logs[1]).toContain('100.0%')
+  })
+})
+
+describe('resumable downloads', () => {
+  it('parses satisfied and unsatisfied content ranges', () => {
+    expect(parseContentRange('bytes 100-199/1000')).toEqual({
+      start: 100,
+      end: 199,
+      total: 1000,
+    })
+    expect(parseContentRange('bytes */1000')).toEqual({ total: 1000 })
+    expect(parseContentRange('invalid')).toBeUndefined()
+  })
+
+  it('requests the remaining range and appends it to a partial archive', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'amaci-zkey-resume-test-'))
+    const archivePath = path.join(tmpDir, 'bundle.tar.gz.part')
+    fs.writeFileSync(archivePath, 'hello ')
+
+    const requestGet = ((
+      _url: string | URL,
+      options: https.RequestOptions,
+      callback: (response: IncomingMessage) => void,
+    ) => {
+      expect(options.headers).toEqual({ Range: 'bytes=6-' })
+
+      const response = new PassThrough() as PassThrough & IncomingMessage
+      response.statusCode = 206
+      response.headers = {
+        'content-length': '5',
+        'content-range': 'bytes 6-10/11',
+      }
+      response.complete = true
+
+      queueMicrotask(() => {
+        callback(response)
+        response.end('world')
+      })
+
+      return new EventEmitter() as unknown as ReturnType<typeof https.get>
+    }) as typeof https.get
+
+    await downloadZKeys(archivePath, 'bundle.tar.gz', 11, requestGet)
+
+    expect(fs.readFileSync(archivePath, 'utf8')).toBe('hello world')
+  })
+
+  it('restarts safely when the server ignores the range request', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'amaci-zkey-restart-test-'))
+    const archivePath = path.join(tmpDir, 'bundle.tar.gz.part')
+    fs.writeFileSync(archivePath, 'old')
+
+    const requestGet = ((
+      _url: string | URL,
+      options: https.RequestOptions,
+      callback: (response: IncomingMessage) => void,
+    ) => {
+      expect(options.headers).toEqual({ Range: 'bytes=3-' })
+
+      const response = new PassThrough() as PassThrough & IncomingMessage
+      response.statusCode = 200
+      response.headers = { 'content-length': '4' }
+      response.complete = true
+
+      queueMicrotask(() => {
+        callback(response)
+        response.end('new!')
+      })
+
+      return new EventEmitter() as unknown as ReturnType<typeof https.get>
+    }) as typeof https.get
+
+    await downloadZKeys(archivePath, 'bundle.tar.gz', 4, requestGet)
+
+    expect(fs.readFileSync(archivePath, 'utf8')).toBe('new!')
+  })
+
+  it('keeps the partial archive after an interrupted response', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'amaci-zkey-interrupt-test-'))
+    const archivePath = path.join(tmpDir, 'bundle.tar.gz.part')
+    fs.writeFileSync(archivePath, 'hello ')
+
+    const requestGet = ((
+      _url: string | URL,
+      _options: https.RequestOptions,
+      callback: (response: IncomingMessage) => void,
+    ) => {
+      const response = new PassThrough() as PassThrough & IncomingMessage
+      response.statusCode = 206
+      response.headers = {
+        'content-length': '5',
+        'content-range': 'bytes 6-10/11',
+      }
+      response.complete = false
+
+      queueMicrotask(() => {
+        callback(response)
+        response.write('wo')
+        response.emit('aborted')
+      })
+
+      return new EventEmitter() as unknown as ReturnType<typeof https.get>
+    }) as typeof https.get
+
+    await expect(
+      downloadZKeys(archivePath, 'bundle.tar.gz', 11, requestGet),
+    ).rejects.toThrow('Download aborted')
+
+    expect(fs.existsSync(archivePath)).toBe(true)
+    expect(fs.statSync(archivePath).size).toBeGreaterThanOrEqual(6)
   })
 })

--- a/src/lib/downloadZkeys.ts
+++ b/src/lib/downloadZkeys.ts
@@ -18,7 +18,197 @@ const ZKEY_ARCHIVE_SIZE: Partial<Record<MaciType, number>> = {
   '9-4-3-125_v6': 8_490_961_031,
 }
 
+const DOWNLOAD_PROGRESS_LOG_INTERVAL_MS = 30_000
+const DOWNLOAD_PROGRESS_PERCENT_STEP = 5
+const DOWNLOAD_PROGRESS_BAR_WIDTH = 20
+
 const activeBundleDownloads = new Map<string, Promise<void>>()
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB']
+  const unitIndex = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  )
+  const value = bytes / 1024 ** unitIndex
+  const precision = unitIndex === 0 ? 0 : 1
+  return `${value.toFixed(precision)} ${units[unitIndex]}`
+}
+
+function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '--'
+
+  const rounded = Math.max(0, Math.round(seconds))
+  const hours = Math.floor(rounded / 3600)
+  const minutes = Math.floor((rounded % 3600) / 60)
+  const remainingSeconds = rounded % 60
+
+  if (hours > 0) return `${hours}h ${minutes}m`
+  if (minutes > 0) return `${minutes}m ${remainingSeconds}s`
+  return `${remainingSeconds}s`
+}
+
+export function formatDownloadProgress(
+  downloadedBytes: number,
+  totalBytes: number,
+  elapsedMs: number,
+  initialBytes: number = 0,
+): string {
+  const downloaded = Math.max(0, downloadedBytes)
+  const elapsedSeconds = Math.max(0, elapsedMs) / 1000
+  const transferredBytes = Math.max(0, downloaded - initialBytes)
+  const bytesPerSecond = elapsedSeconds > 0
+    ? transferredBytes / elapsedSeconds
+    : 0
+  const speed = bytesPerSecond > 0 ? `${formatBytes(bytesPerSecond)}/s` : '--'
+
+  if (totalBytes <= 0) {
+    return `${formatBytes(downloaded)} downloaded | ${speed}`
+  }
+
+  const ratio = Math.min(1, downloaded / totalBytes)
+  const completedWidth = Math.floor(ratio * DOWNLOAD_PROGRESS_BAR_WIDTH)
+  const bar = `${'='.repeat(completedWidth)}${' '.repeat(
+    DOWNLOAD_PROGRESS_BAR_WIDTH - completedWidth,
+  )}`
+  const eta = bytesPerSecond > 0
+    ? formatDuration((totalBytes - downloaded) / bytesPerSecond)
+    : '--'
+
+  return `[${bar}] ${(ratio * 100).toFixed(1)}% ${formatBytes(downloaded)} / ${formatBytes(totalBytes)} | ${speed} | ETA ${eta}`
+}
+
+type DownloadProgressReporterOptions = {
+  isTTY?: boolean
+  log?: (message: string) => void
+  now?: () => number
+  stream?: NodeJS.WritableStream
+  logIntervalMs?: number
+  percentStep?: number
+  initialBytes?: number
+}
+
+export function createDownloadProgressReporter(
+  fileName: string,
+  totalBytes: number,
+  options: DownloadProgressReporterOptions = {},
+) {
+  const isTTY = options.isTTY ?? Boolean(process.stderr.isTTY)
+  const log = options.log ?? console.log
+  const now = options.now ?? Date.now
+  const stream = options.stream ?? process.stderr
+  const logIntervalMs = options.logIntervalMs ?? DOWNLOAD_PROGRESS_LOG_INTERVAL_MS
+  const percentStep = Math.max(
+    1,
+    options.percentStep ?? DOWNLOAD_PROGRESS_PERCENT_STEP,
+  )
+  const initialBytes = Math.max(
+    0,
+    Math.min(options.initialBytes ?? 0, totalBytes > 0 ? totalBytes : Infinity),
+  )
+  const startedAt = now()
+  let downloadedBytes = initialBytes
+  let lastLogAt = startedAt
+  const initialPercent = totalBytes > 0 ? (initialBytes / totalBytes) * 100 : 0
+  let nextPercent = (Math.floor(initialPercent / percentStep) + 1) * percentStep
+
+  const progressBar = isTTY && totalBytes > 0
+    ? new ProgressBar(
+      'Downloading [:bar] :percent | :downloaded / :totalSize | :speed | ETA :eta s',
+      {
+        complete: '=',
+        incomplete: ' ',
+        width: DOWNLOAD_PROGRESS_BAR_WIDTH,
+        total: totalBytes,
+        curr: initialBytes,
+        stream,
+      },
+    )
+    : undefined
+
+  const tokens = () => {
+    const elapsedMs = Math.max(0, now() - startedAt)
+    const transferredBytes = Math.max(0, downloadedBytes - initialBytes)
+    const bytesPerSecond = elapsedMs > 0
+      ? transferredBytes / (elapsedMs / 1000)
+      : 0
+    return {
+      downloaded: formatBytes(downloadedBytes),
+      totalSize: formatBytes(totalBytes),
+      speed: bytesPerSecond > 0 ? `${formatBytes(bytesPerSecond)}/s` : '--',
+    }
+  }
+
+  if (!progressBar) {
+    const action = initialBytes > 0 ? 'Resuming' : 'Downloading'
+    log(
+      `${action} ${fileName}: ${formatDownloadProgress(
+        initialBytes,
+        totalBytes,
+        0,
+        initialBytes,
+      )}`,
+    )
+  }
+
+  const update = (downloaded: number) => {
+    downloadedBytes = Math.max(downloadedBytes, downloaded)
+
+    if (progressBar) {
+      const increment = downloadedBytes - progressBar.curr
+      if (increment > 0) progressBar.tick(increment, tokens())
+      return
+    }
+
+    // The completion path emits the final 100% line with a distinct label.
+    if (totalBytes > 0 && downloadedBytes >= totalBytes) return
+
+    const currentTime = now()
+    const percent = totalBytes > 0
+      ? (downloadedBytes / totalBytes) * 100
+      : 0
+    const reachedPercentStep = totalBytes > 0 && percent >= nextPercent
+    const reachedTimeInterval = currentTime - lastLogAt >= logIntervalMs
+    if (!reachedPercentStep && !reachedTimeInterval) return
+
+    while (percent >= nextPercent) nextPercent += percentStep
+    lastLogAt = currentTime
+    log(
+      `Downloading ${fileName}: ${formatDownloadProgress(
+        downloadedBytes,
+        totalBytes,
+        currentTime - startedAt,
+        initialBytes,
+      )}`,
+    )
+  }
+
+  const complete = (downloaded: number) => {
+    downloadedBytes = Math.max(downloadedBytes, downloaded)
+    if (progressBar) {
+      update(downloadedBytes)
+      if (!progressBar.complete) progressBar.terminate()
+      return
+    }
+
+    log(
+      `Downloaded ${fileName}: ${formatDownloadProgress(
+        downloadedBytes,
+        totalBytes,
+        now() - startedAt,
+        initialBytes,
+      )}`,
+    )
+  }
+
+  const stop = () => {
+    if (progressBar && !progressBar.complete) progressBar.terminate()
+  }
+
+  return { update, complete, stop }
+}
 
 function ensureDir(dir: string) {
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
@@ -157,8 +347,10 @@ export async function downloadAndExtractZKeys(
   if (!shouldReplace) return
 
   ensureDir(targetZkeyRoot)
+  const downloadRoot = path.join(targetZkeyRoot, '.amaci-zkey-downloads')
+  ensureDir(downloadRoot)
   const workspace = fs.mkdtempSync(path.join(targetZkeyRoot, '.amaci-zkey-'))
-  const archivePath = path.join(workspace, fileName)
+  const archivePath = path.join(downloadRoot, `${fileName}.part`)
   const extractRoot = path.join(workspace, 'extract')
   const stagedBundleDir = path.join(workspace, 'stage', circuitPower)
 
@@ -166,9 +358,19 @@ export async function downloadAndExtractZKeys(
   ensureDir(path.dirname(stagedBundleDir))
 
   try {
-    await downloadZKeysWithRetry(archivePath, fileName, 3)
-    verifyArchiveSize(circuitPower, archivePath)
-    await verifyArchiveChecksum(circuitPower, archivePath)
+    await downloadZKeysWithRetry(
+      archivePath,
+      fileName,
+      3,
+      ZKEY_ARCHIVE_SIZE[circuitPower],
+    )
+    try {
+      verifyArchiveSize(circuitPower, archivePath)
+      await verifyArchiveChecksum(circuitPower, archivePath)
+    } catch (error) {
+      fs.rmSync(archivePath, { force: true })
+      throw error
+    }
     await extractZKeys(archivePath, extractRoot)
 
     const sourceBundleDir = locateBundleDirectory(extractRoot, circuitPower)
@@ -181,6 +383,7 @@ export async function downloadAndExtractZKeys(
     }
 
     replaceBundleDirectory(stagedBundleDir, bundleRoot)
+    fs.rmSync(archivePath, { force: true })
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true })
   }
@@ -218,44 +421,173 @@ export async function ensureZkeyBundle(
   }
 }
 
-async function downloadZKeys(archivePath: string, fileName: string) {
+type ParsedContentRange = {
+  start?: number
+  end?: number
+  total?: number
+}
+
+export function parseContentRange(value?: string): ParsedContentRange | undefined {
+  if (!value) return undefined
+
+  const satisfied = /^bytes\s+(\d+)-(\d+)\/(\d+|\*)$/i.exec(value)
+  if (satisfied) {
+    const start = Number(satisfied[1])
+    const end = Number(satisfied[2])
+    const total = satisfied[3] === '*' ? undefined : Number(satisfied[3])
+    if (end < start) return undefined
+    return { start, end, total }
+  }
+
+  const unsatisfied = /^bytes\s+\*\/(\d+)$/i.exec(value)
+  if (unsatisfied) return { total: Number(unsatisfied[1]) }
+
+  return undefined
+}
+
+function numericHeader(value: string | string[] | undefined): number {
+  const raw = Array.isArray(value) ? value[0] : value
+  const parsed = Number.parseInt(raw || '0', 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+}
+
+export async function downloadZKeys(
+  archivePath: string,
+  fileName: string,
+  expectedSize?: number,
+  requestGet: typeof https.get = https.get,
+) {
   const url = `https://vota-zkey.s3.ap-southeast-1.amazonaws.com/${fileName}`
   console.log(url)
 
-  // Initialize progress bar
-  const progressBar = new ProgressBar('Downloading [:bar] :percent :etas', {
-    complete: '=',
-    incomplete: ' ',
-    width: 20,
-    total: 0, // Will be updated dynamically
-  })
+  let resumeOffset = fs.existsSync(archivePath)
+    ? fs.statSync(archivePath).size
+    : 0
+  if (expectedSize && resumeOffset > expectedSize) {
+    console.warn(
+      `Discarding oversized partial download for ${fileName}: ${resumeOffset} > ${expectedSize}`,
+    )
+    fs.rmSync(archivePath, { force: true })
+    resumeOffset = 0
+  }
+  if (expectedSize && resumeOffset === expectedSize) {
+    console.log(
+      `Found a complete partial download for ${fileName}; verifying checksum`,
+    )
+    return
+  }
 
   await new Promise<void>((resolve, reject) => {
     let settled = false
     let file: fs.WriteStream | undefined
+    let progress: ReturnType<typeof createDownloadProgressReporter> | undefined
+    let downloadedBytes = resumeOffset
 
-    const fail = (error: Error) => {
+    const fail = (error: Error, discardPartial: boolean = false) => {
       if (settled) return
       settled = true
-      file?.destroy()
-      try {
-        fs.rmSync(archivePath, { force: true })
-      } catch {}
-      reject(error)
+      progress?.stop()
+
+      const rejectAfterClose = () => {
+        if (discardPartial) {
+          try {
+            fs.rmSync(archivePath, { force: true })
+          } catch {}
+        }
+        reject(error)
+      }
+
+      if (file && !file.closed) {
+        file.once('close', rejectAfterClose)
+        file.destroy()
+      } else {
+        rejectAfterClose()
+      }
     }
 
-    const request = https.get(url, (response) => {
-      if (response.statusCode !== 200) {
+    const headers = resumeOffset > 0
+      ? { Range: `bytes=${resumeOffset}-` }
+      : undefined
+    const request = requestGet(url, { headers }, (response) => {
+      const statusCode = response.statusCode || 0
+      const contentRange = parseContentRange(response.headers['content-range'])
+      let writeOffset = resumeOffset
+      let writeFlags: 'a' | 'w' = resumeOffset > 0 ? 'a' : 'w'
+
+      if (resumeOffset > 0 && statusCode === 206) {
+        if (contentRange?.start !== resumeOffset) {
+          response.resume()
+          fail(
+            new Error(
+              `Invalid Content-Range while resuming ${fileName}: expected start ${resumeOffset}, got ${response.headers['content-range'] || 'missing'}`,
+            ),
+            true,
+          )
+          return
+        }
+      } else if (resumeOffset > 0 && statusCode === 200) {
+        console.warn(
+          `Download server ignored the Range request for ${fileName}; restarting from byte 0`,
+        )
+        writeOffset = 0
+        downloadedBytes = 0
+        writeFlags = 'w'
+      } else if (resumeOffset > 0 && statusCode === 416) {
         response.resume()
-        fail(new Error(`Invalid status code: ${response.statusCode}`))
+        if (contentRange?.total === resumeOffset) {
+          settled = true
+          resolve()
+        } else {
+          fail(
+            new Error(
+              `Range request rejected for ${fileName}: local=${resumeOffset}, remote=${contentRange?.total ?? 'unknown'}`,
+            ),
+            true,
+          )
+        }
+        return
+      } else if (resumeOffset === 0 && statusCode === 206) {
+        if (contentRange?.start !== 0) {
+          response.resume()
+          fail(
+            new Error(
+              `Invalid initial Content-Range for ${fileName}: ${response.headers['content-range'] || 'missing'}`,
+            ),
+            true,
+          )
+          return
+        }
+      } else if (statusCode !== 200) {
+        response.resume()
+        fail(new Error(`Invalid status code: ${statusCode}`))
         return
       }
 
-      const totalSize = parseInt(response.headers['content-length'] || '0', 10)
-      progressBar.total = totalSize
+      const responseSize = numericHeader(response.headers['content-length'])
+      const responseTotal = contentRange?.total
+        || (responseSize > 0
+          ? (statusCode === 206 ? writeOffset + responseSize : responseSize)
+          : 0)
+      const totalSize = responseTotal || expectedSize || 0
+      if (expectedSize && totalSize > 0 && totalSize !== expectedSize) {
+        response.resume()
+        fail(
+          new Error(
+            `Unexpected archive size for ${fileName}: expected ${expectedSize}, server reported ${totalSize}`,
+          ),
+          true,
+        )
+        return
+      }
+      progress = createDownloadProgressReporter(fileName, totalSize, {
+        initialBytes: writeOffset,
+      })
 
-      file = fs.createWriteStream(archivePath, { flags: 'w' })
-      response.on('data', (chunk) => progressBar.tick(chunk.length))
+      file = fs.createWriteStream(archivePath, { flags: writeFlags })
+      response.on('data', (chunk: Buffer) => {
+        downloadedBytes += chunk.length
+        progress?.update(downloadedBytes)
+      })
       response.on('aborted', () => fail(new Error('Download aborted')))
       response.on('error', fail)
       file.on('error', fail)
@@ -265,7 +597,17 @@ async function downloadZKeys(archivePath: string, fileName: string) {
           fail(new Error('Download ended before the response was complete'))
           return
         }
+        if (totalSize > 0 && downloadedBytes !== totalSize) {
+          fail(
+            new Error(
+              `Download size mismatch for ${fileName}: expected ${totalSize}, got ${downloadedBytes}`,
+            ),
+            downloadedBytes > totalSize,
+          )
+          return
+        }
         settled = true
+        progress?.complete(downloadedBytes)
         file?.close(() => resolve())
       })
       response.pipe(file)
@@ -282,11 +624,12 @@ async function downloadZKeysWithRetry(
   archivePath: string,
   fileName: string,
   retries: number,
+  expectedSize?: number,
 ) {
   let attempt = 0
   while (true) {
     try {
-      await downloadZKeys(archivePath, fileName)
+      await downloadZKeys(archivePath, fileName, expectedSize)
       return
     } catch (e) {
       attempt++


### PR DESCRIPTION
## What changed

- show interactive zkey download progress with size, speed, percentage, and ETA
- emit throttled progress lines under systemd and journal
- persist partial zkey archives across retries and operator restarts
- resume downloads with validated HTTP Range responses
- fall back safely when a server ignores Range requests
- discard partial archives that fail size or checksum validation

## Why

The v6 zkey archive is approximately 8.49 GB, so slow or interrupted connections need visible progress and must not restart the entire download.

## Impact

No configuration changes are required. Round processing and circuit behavior are unchanged.

## Validation

- 43 tests passed
- TypeScript build passed
- npm publish dry run passed
- live S3 endpoint returned 206 Partial Content with Accept-Ranges: bytes and the expected total size